### PR TITLE
Generalize localhost port in benchmarking harness.

### DIFF
--- a/benchmarking.html
+++ b/benchmarking.html
@@ -15,9 +15,9 @@
         window.location.protocol === "file:";
       const script = document.createElement("script");
       script.type = "module";
-      script.src = (isLocalhost ? "http://localhost:8080" : "https://jowens.github.io") + "/webgpu-benchmarking/benchmarking_chrome.mjs";
+      script.src = (isLocalhost ? window.location.origin : "https://jowens.github.io") + "/webgpu-benchmarking/benchmarking_chrome.mjs";
       document.body.appendChild(script);
-    // <script src="http://localhost:8080/webgpu-benchmarking/benchmarking_chrome.mjs" type="module"></script>
+    // <script src="http://localhost:8000/webgpu-benchmarking/benchmarking_chrome.mjs" type="module"></script>
     </script>
   </body>
 </html>

--- a/benchmarking_chrome.mjs
+++ b/benchmarking_chrome.mjs
@@ -4,7 +4,7 @@ const isLocalhost =
   window.location.protocol === "file:";
 
 const modulePath =
-  (isLocalhost ? "http://localhost:8080" : "https://jowens.github.io") +
+  (isLocalhost ? window.location.origin : "https://jowens.github.io") +
   "/webgpu-benchmarking/benchmarking.mjs";
 
 import(modulePath)
@@ -15,5 +15,5 @@ import(modulePath)
     console.error("Error loading module", error);
   });
 
-//import { main } from "http://localhost:8080/webgpu-benchmarking/benchmarking.mjs";
+//import { main } from "http://localhost:8000/webgpu-benchmarking/benchmarking.mjs";
 // main(navigator);


### PR DESCRIPTION
Use window.location.origin instead of hardcoded port against localhost, and revert commented-out changes to port 8080. More work could be done to produce a URL in the same folder as the top-level HTML file.

This doesn't work in the standalone harness so that's being left alone.