### PR TITLE
Fix CSS loading for GitHub Pages: use remote_theme with proper Minima…

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,10 +6,11 @@ url: "https://gridwise-webgpu.github.io"
 github_username: gridwise-webgpu
 
 markdown: kramdown
-theme: minima
+remote_theme: jekyll/minima
 permalink: pretty
 plugins:
   - jekyll-feed
+  - jekyll-remote-theme
 
 # Only show About in header navigation
 header_pages:

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -3,7 +3,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     {%- seo -%}
-    <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
     {%- feed_meta -%}
     {%- if jekyll.environment == 'production' and site.google_analytics -%}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+
+{%- include head.html -%}
+
+<body>
+
+{%- include header.html -%}
+
+<main class="page-content" aria-label="Content">
+  <div class="wrapper">
+    {{ content }}
+  </div>
+</main>
+
+{%- include footer.html -%}
+
+</body>
+
+</html>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,6 +1,11 @@
 ---
 ---
-@import "minima";
+
+@import
+  "minima/skins/{{ site.minima.skin | default: 'classic' }}",
+  "minima/initialize";
+
+/* Custom styles for Gridwise documentation */
 
 /* Reset browser defaults for consistent rendering */
 * {


### PR DESCRIPTION
… imports

- Change from theme: minima to remote_theme: jekyll/minima
- Add jekyll-remote-theme to plugins list
- Update style.scss to import minima/skins and minima/initialize
- Create default.html layout for proper HTML structure
- Fix head.html to only reference style.css (remove missing main.css)

This ensures CSS loads correctly both locally and on GitHub Pages.