### PR TITLE
Each example should have a back button to return to the examples list ("Back to Examples") #33

### DIFF
--- a/examples/gridwise.css
+++ b/examples/gridwise.css
@@ -119,6 +119,17 @@ ul.test-list li.fail {
 
 .back-link {
   display: inline-block;
+  padding: 5px 12px;
+  background: #39bda7;
+  color: white;
+  text-decoration: none;
+  border-radius: 4px;
   margin-bottom: 1em;
-  font-size: 0.9em;
+  font-size: 13px;
+  transition: background 0.2s;
+}
+.back-link:hover {
+  background: #2a9a87;
+  color: white;
+  text-decoration: none;
 }

--- a/examples/gridwise.css
+++ b/examples/gridwise.css
@@ -116,3 +116,9 @@ ul.test-list li.fail {
 #large-section {
   display: none;
 }
+
+.back-link {
+  display: inline-block;
+  margin-bottom: 1em;
+  font-size: 0.9em;
+}

--- a/examples/gridwise.css
+++ b/examples/gridwise.css
@@ -116,3 +116,20 @@ ul.test-list li.fail {
 #large-section {
   display: none;
 }
+
+.back-link {
+  display: inline-block;
+  padding: 5px 12px;
+  background: #39bda7;
+  color: white;
+  text-decoration: none;
+  border-radius: 4px;
+  margin-bottom: 1em;
+  font-size: 13px;
+  transition: background 0.2s;
+}
+.back-link:hover {
+  background: #2a9a87;
+  color: white;
+  text-decoration: none;
+}

--- a/examples/reduce_example.html
+++ b/examples/reduce_example.html
@@ -10,6 +10,7 @@
     />
   </head>
   <body>
+    <a href="/gridwise/examples/" class="back-link">← Back to Examples</a>
     <h1>Gridwise Reduce Primitive Example</h1>
     <p>
       This example calls Gridwise's <code>reduce</code> primitive. You can look

--- a/examples/reduce_perf.html
+++ b/examples/reduce_perf.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" />
   </head>
   <body>
+    <a href="/gridwise/examples/" class="back-link">← Back to Examples</a>
     <h1>Reduce Performance</h1>
     <p>
       This example is a self-contained use of the <code>reduce</code>

--- a/examples/regression.html
+++ b/examples/regression.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="gridwise.css" />
   </head>
   <body>
+    <a href="/gridwise/examples/" class="back-link">← Back to Examples</a>
     <h1>Gridwise Regression Tests</h1>
     <ul id="test-list" class="test-list"></ul>
     <div id="summary" class="summary">Running…</div>

--- a/examples/scan_example.html
+++ b/examples/scan_example.html
@@ -10,6 +10,7 @@
     />
   </head>
   <body>
+    <a href="/gridwise/examples/" class="back-link">← Back to Examples</a>
     <h1>Gridwise Scan Primitive Example</h1>
     <p>
       This example calls Gridwise's <code>scan</code> primitive. You can look at

--- a/examples/scan_pane_example.html
+++ b/examples/scan_pane_example.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="gridwise.css" />
   </head>
   <body>
+    <a href="/gridwise/examples/" class="back-link">← Back to Examples</a>
     <h1>Scan / Reduce Example, with Configuration Pane</h1>
     <div id="instructions">
       <p>Set your parameters in the pane and click "Start" to run and validate a WebGPU scan/reduce.</p>

--- a/examples/scan_sort_perf.html
+++ b/examples/scan_sort_perf.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" />
   </head>
   <body>
+    <a href="/gridwise/examples/" class="back-link">← Back to Examples</a>
     <h1>Scan / Sort Performance</h1>
     <p>
       This example is a self-contained use of the <code>scan</code> and

--- a/examples/sort_example.html
+++ b/examples/sort_example.html
@@ -10,6 +10,7 @@
     />
   </head>
   <body>
+    <a href="/gridwise/examples/" class="back-link">← Back to Examples</a>
     <h1>Gridwise Sort Primitive Example</h1>
     <p>
       This example calls Gridwise's <code>sort</code> primitive. You can look at


### PR DESCRIPTION
Button that redirects to the examples section

<img width="779" height="612" alt="Screenshot 2026-03-04 at 3 03 27 PM" src="https://github.com/user-attachments/assets/0af68396-f748-4d08-bff5-2dc38404cc47" />
